### PR TITLE
Potential fix for code scanning alert no. 4: Use of password hash with insufficient computational effort

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "@prisma/client": "^5.22.0",
     "fastify": "^5.3.2",
     "jsonwebtoken": "^9.0.2",
-    "nodemon": "^3.1.7"
+    "nodemon": "^3.1.7",
+    "bcrypt": "^6.0.0"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
Potential fix for [https://github.com/a52cents/ecommerce/security/code-scanning/4](https://github.com/a52cents/ecommerce/security/code-scanning/4)

To fix the issue, we will replace the use of `sha1` with a secure password hashing algorithm, such as `bcrypt`. The `bcrypt` library is specifically designed for password hashing and includes built-in salting and computational cost mechanisms to make brute-force attacks computationally expensive.

Steps to fix:
1. Replace the `createHash("sha1")` logic with `bcrypt.hashSync` for hashing passwords during signup.
2. Use `bcrypt.compareSync` to verify passwords during login instead of manually hashing and comparing.
3. Add the necessary import for the `bcrypt` library.
4. Ensure the salt is generated dynamically by `bcrypt` rather than relying on `process.env.SALT`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
