### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,12 @@ import fastifyStatic from '@fastify/static';
 
 const fastify = Fastify({ logger: true });
 
+// Register rate limiting plugin
+await fastify.register(import('@fastify/rate-limit'), {
+  max: 100, // maximum 100 requests
+  timeWindow: '1 minute', // per minute
+});
+
 await fastify.register(fastifyCors, {
   origin: "*", // allow all
   methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
@@ -54,7 +60,7 @@ registerAuthRoutes(fastify);
 registerPostRoutes(fastify);
 
 // Serve index.html at '/'
-fastify.get('/', async (request, reply) => {
+fastify.get('/', { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } }, async (request, reply) => {
   const __filename = fileURLToPath(import.meta.url);
   const __dirname = path.dirname(__filename);
   const html = await readFile(path.join(__dirname, 'index.html'), 'utf-8');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "@prisma/client": "^5.22.0",
     "fastify": "^5.3.2",
     "jsonwebtoken": "^9.0.2",
-    "nodemon": "^3.1.7"
+    "nodemon": "^3.1.7",
+    "@fastify/rate-limit": "^10.3.0"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
Potential fix for [https://github.com/a52cents/ecommerce/security/code-scanning/2](https://github.com/a52cents/ecommerce/security/code-scanning/2)

To address the issue, we will add rate limiting to the Fastify server using the `@fastify/rate-limit` plugin. This plugin allows us to define a maximum number of requests per time window for specific routes or globally. 

The fix involves:
1. Installing the `@fastify/rate-limit` package.
2. Registering the rate-limiting plugin with appropriate configuration (e.g., maximum requests per minute).
3. Applying rate limiting to the root route (`/`) where the file system access occurs.

This ensures that the server can handle requests efficiently while preventing abuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
